### PR TITLE
CBASP-23: Refactor initialization and setup/configuration

### DIFF
--- a/Couchbase.AspNet.UnitTests/Couchbase.AspNet.UnitTests.csproj
+++ b/Couchbase.AspNet.UnitTests/Couchbase.AspNet.UnitTests.csproj
@@ -67,10 +67,13 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="ProviderHelperTests.cs" />
     <Compile Include="SessionStateItemTests.cs" />
   </ItemGroup>
   <ItemGroup>
-    <None Include="app.config" />
+    <None Include="app.config">
+      <SubType>Designer</SubType>
+    </None>
     <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>

--- a/Couchbase.AspNet.UnitTests/ProviderHelperTests.cs
+++ b/Couchbase.AspNet.UnitTests/ProviderHelperTests.cs
@@ -1,0 +1,79 @@
+﻿using System.Collections.Specialized;
+using NUnit.Framework;
+
+namespace Couchbase.AspNet.UnitTests
+{
+    [TestFixture]
+    public class ProviderHelperTests
+    {
+        [Test]
+        [Category("Integration")]
+        public void GetCluster_CouchbaseSession_ReturnsCluster()
+        {
+            var cluster = ProviderHelper.GetCluster("couchbase-session", null);
+
+            Assert.IsNotNull(cluster);
+        }
+
+        [Test]
+        [Category("Integration")]
+        public void GetBucket_CouchbaseSession_ReturnsBucket()
+        {
+            var config = new NameValueCollection {
+                { "bucket", "memcached" }
+            };
+            var cluster = ProviderHelper.GetCluster("couchbase-session", null);
+            var bucket = ProviderHelper.GetBucket("default", config, cluster);
+
+            Assert.IsNotNull(bucket);
+        }
+
+        [Test]
+        [Category("Integration")]
+        public void GetBucket_CouchbaseSession_ReturnsMemcachedBucket()
+        {
+            var config = new NameValueCollection {
+                { "bucket", "memcached" }
+            };
+            var cluster = ProviderHelper.GetCluster("couchbase-session", null);
+            var bucket = ProviderHelper.GetBucket("default", config, cluster);
+
+            Assert.AreEqual(typeof(MemcachedBucket), bucket.GetType());
+        }
+
+        [Test]
+        [Category("Integration")]
+        public void GetCluster_CouchbaseCache_ReturnsCluster()
+        {
+            var cluster = ProviderHelper.GetCluster("couchbase-cache", null);
+
+            Assert.IsNotNull(cluster);
+        }
+
+        [Test]
+        [Category("Integration")]
+        public void GetBucket_CouchbaseCache_ReturnsBucket()
+        {
+            var config = new NameValueCollection {
+                { "bucket", "default" }
+            };
+            var cluster = ProviderHelper.GetCluster("couchbase-cache", null);
+            var bucket = ProviderHelper.GetBucket("default", config, cluster);
+
+            Assert.IsNotNull(bucket);
+        }
+
+        [Test]
+        [Category("Integration")]
+        public void GetBucket_CouchbaseCache_ReturnsMemcachedBucket()
+        {
+            var config = new NameValueCollection {
+                { "bucket", "default" }
+            };
+            var cluster = ProviderHelper.GetCluster("couchbase-cache", null);
+            var bucket = ProviderHelper.GetBucket("default", config, cluster);
+
+            Assert.AreEqual(typeof(CouchbaseBucket), bucket.GetType());
+        }
+    }
+}

--- a/Couchbase.AspNet.UnitTests/app.config
+++ b/Couchbase.AspNet.UnitTests/app.config
@@ -1,5 +1,25 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <configuration>
+ <configSections>
+      <section name="couchbase-session" type="Couchbase.Configuration.Client.Providers.CouchbaseClientSection, Couchbase.NetClient" />
+      <section name="couchbase-cache" type="Couchbase.Configuration.Client.Providers.CouchbaseClientSection, Couchbase.NetClient" />
+  </configSections>
+  <couchbase-session>
+    <servers>
+      <add uri="http://localhost:8091/"></add>
+    </servers>
+    <buckets>
+      <add name="memcached"></add>
+    </buckets>
+  </couchbase-session>
+   <couchbase-cache>
+    <servers>
+      <add uri="http://localhost:8091/"></add>
+    </servers>
+    <buckets>
+      <add name="default"></add>
+    </buckets>
+  </couchbase-cache>
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>

--- a/Couchbase.AspNet/CouchbaseBucketFactory.cs
+++ b/Couchbase.AspNet/CouchbaseBucketFactory.cs
@@ -1,8 +1,10 @@
-﻿using System.Collections.Specialized;
+﻿using System;
+using System.Collections.Specialized;
 using Couchbase.Core;
 
 namespace Couchbase.AspNet
 {
+    [Obsolete("Use CouchbaseConfigSection as factory instead.")]
     public sealed class CouchbaseBucketFactory : ICouchbaseBucketFactory
     {
         /// <summary>

--- a/Couchbase.AspNet/ICouchbaseBucketFactory.cs
+++ b/Couchbase.AspNet/ICouchbaseBucketFactory.cs
@@ -1,8 +1,10 @@
-﻿using System.Collections.Specialized;
+﻿using System;
+using System.Collections.Specialized;
 using Couchbase.Core;
 
 namespace Couchbase.AspNet
 {
+    [Obsolete("Use CouchbaseConfigSection as factory instead.")]
     public interface ICouchbaseBucketFactory
     {
         /// <summary>

--- a/Couchbase.AspNet/OutputCache/CouchbaseOutputCacheProvider.cs
+++ b/Couchbase.AspNet/OutputCache/CouchbaseOutputCacheProvider.cs
@@ -10,6 +10,7 @@ namespace Couchbase.AspNet.OutputCache
 {
     public class CouchbaseOutputCacheProvider : OutputCacheProvider
     {
+        private ICluster _cluster;
         private IBucket _bucket;
 
         /// <summary>
@@ -32,12 +33,16 @@ namespace Couchbase.AspNet.OutputCache
             // Initialize the base class
             base.Initialize(name, config);
 
-            // Create our Couchbase bucket instance
-            _bucket = ProviderHelper.GetBucket(name, config);
+            // Create our Cluster based off the CouchbaseConfigSection
+            _cluster = ProviderHelper.GetCluster(name, config);
+
+            // Create the bucket based off the name provided in the
+            _bucket = ProviderHelper.GetBucket(name, config, _cluster);
 
             // Allow optional prefix to be used for this application
             var prefix = ProviderHelper.GetAndRemove(config, "prefix", false);
-            if (prefix != null) {
+            if (prefix != null)
+            {
                 _prefix = prefix;
             }
 
@@ -99,7 +104,8 @@ namespace Couchbase.AspNet.OutputCache
 
             // If the item got evicted between the Add and the Get (very rare) we store it anyway, 
             // but this time with Set to make sure it always gets into the cache
-            if (retval == null) {
+            if (retval == null)
+            {
                 _bucket.Insert(key, entry, expiration);
                 retval = entry;
             }
@@ -154,7 +160,8 @@ namespace Couchbase.AspNet.OutputCache
         private byte[] Serialize(
             object value)
         {
-            using (var ms = new MemoryStream()) {
+            using (var ms = new MemoryStream())
+            {
                 new BinaryFormatter().Serialize(ms, value);
                 return ms.ToArray();
             }
@@ -168,10 +175,12 @@ namespace Couchbase.AspNet.OutputCache
         private object DeSerialize(
             byte[] bytes)
         {
-            if (bytes == null) {
+            if (bytes == null)
+            {
                 return null;
             }
-            using (var ms = new MemoryStream(bytes)) {
+            using (var ms = new MemoryStream(bytes))
+            {
                 return new BinaryFormatter().Deserialize(ms);
             }
         }

--- a/Couchbase.AspNet/Properties/AssemblyInfo.cs
+++ b/Couchbase.AspNet/Properties/AssemblyInfo.cs
@@ -34,3 +34,5 @@ using System.Runtime.InteropServices;
 // [assembly: AssemblyVersion("1.0.*")]
 [assembly: AssemblyVersion("1.2.1.0")]
 [assembly: AssemblyFileVersion("1.2.1.0")]
+
+[assembly: InternalsVisibleTo("Couchbase.AspNet.UnitTests")]

--- a/Couchbase.AspNet/SessionState/CouchbaseSessionStateProvider.cs
+++ b/Couchbase.AspNet/SessionState/CouchbaseSessionStateProvider.cs
@@ -8,6 +8,7 @@ namespace Couchbase.AspNet.SessionState
 {
     public class CouchbaseSessionStateProvider : SessionStateStoreProviderBase
     {
+        private ICluster _cluster;
         private IBucket _bucket;
         private static bool _exclusiveAccess;
 
@@ -40,8 +41,11 @@ namespace Couchbase.AspNet.SessionState
             // Initialize the base class
             base.Initialize(name, config);
 
-            // Create our Couchbase bucket instance
-            _bucket = ProviderHelper.GetBucket(name, config);
+            // Create our Cluster based off the CouchbaseConfigSection
+            _cluster = ProviderHelper.GetCluster(name, config);
+
+            // Create the bucket based off the name provided in the
+            _bucket = ProviderHelper.GetBucket(name, config, _cluster);
 
             // By default use exclusive session access. But allow it to be overridden in the config file
             var exclusive = ProviderHelper.GetAndRemove(config, "exclusiveAccess", false) ?? "true";
@@ -66,6 +70,10 @@ namespace Couchbase.AspNet.SessionState
         /// </summary>
         public override void Dispose()
         {
+            if (_cluster != null) {
+                _cluster.Dispose();
+                _cluster = null;
+            }
         }
 
         /// <summary>

--- a/CouchbaseAspNetSample/Web.config
+++ b/CouchbaseAspNetSample/Web.config
@@ -5,7 +5,8 @@
   -->
 <configuration>
   <configSections>
-    <section name="couchbase-caching" type="Couchbase.Configuration.Client.Providers.CouchbaseClientSection, Couchbase.NetClient" />
+      <section name="couchbase-caching" type="Couchbase.Configuration.Client.Providers.CouchbaseClientSection, Couchbase.NetClient" />
+      <section name="couchbase-session" type="Couchbase.Configuration.Client.Providers.CouchbaseClientSection, Couchbase.NetClient" />
     <sectionGroup name="common">
       <section name="logging" type="Common.Logging.ConfigurationSectionHandler, Common.Logging" />
     </sectionGroup>
@@ -16,13 +17,22 @@
     <add key="ClientValidationEnabled" value="true" />
     <add key="UnobtrusiveJavaScriptEnabled" value="true" />
   </appSettings>
-  <couchbase-caching>
+  <couchbase-session>
     <servers>
       <!-- changes in appSettings section should also be reflected here -->
-      <add uri="http://10.141.150.101:8091/"></add>
+      <add uri="http://localhost:8091/"></add>
     </servers>
     <buckets>
       <add name="memcached"></add>
+    </buckets>
+  </couchbase-session>
+  <couchbase-caching>
+    <servers>
+      <!-- changes in appSettings section should also be reflected here -->
+      <add uri="http://localhost:8091/"></add>
+    </servers>
+    <buckets>
+      <add name="default"></add>
     </buckets>
   </couchbase-caching>
   <common>
@@ -81,15 +91,15 @@
         <add namespace="System.Web.WebPages" />
       </namespaces>
     </pages>
-    <sessionState customProvider="Couchbase" mode="Custom">
+    <sessionState customProvider="couchbase-session" mode="Custom">
       <providers>
-        <add name="Couchbase" type="Couchbase.AspNet.SessionState.CouchbaseSessionStateProvider, Couchbase.AspNet" bucket="memcached" headerPrefix="header-" dataPrefix="data-" factory="Couchbase.AspNet.CouchbaseBucketFactory" exclusiveAccess="false" />
+        <add name="couchbase-session" type="Couchbase.AspNet.SessionState.CouchbaseSessionStateProvider, Couchbase.AspNet" bucket="memcached" headerPrefix="header-" dataPrefix="data-" exclusiveAccess="false" />
       </providers>
     </sessionState>
     <caching>
-      <outputCache defaultProvider="CouchbaseCache">
+      <outputCache defaultProvider="couchbase-caching">
         <providers>
-          <add name="CouchbaseCache" type="Couchbase.AspNet.OutputCache.CouchbaseOutputCacheProvider, Couchbase.AspNet" bucket="default" prefix="cache-" factory="Couchbase.AspNet.CouchbaseBucketFactory" />
+          <add name="couchbase-caching" type="Couchbase.AspNet.OutputCache.CouchbaseOutputCacheProvider, Couchbase.AspNet" bucket="default" prefix="cache-" />
         </providers>
       </outputCache>
     </caching>


### PR DESCRIPTION
Motivation
----------
Changes providers so that they no longer depend on ClusterHelper, so that
you can use different clusters for session and caching. Also, simplifies
configuration by removing need for CouchbaseBucketFactory.

Modifications
-------------
Make CouchbaseBucketFactory obsolete. Remove dependency on ClusterHelper;
use Cluster instead and scope to provider. Change configuration so that a
the bucket name in the SessionState and OutputCaching sections must be the
same name as the bucket you wish to use in your
CouchbaseConfigurationSection. Also, the name of on the SessionState or
OutputCache must match the CouchbaseConfigSection, so that upon
initialization the provider can lookup the correct bucket configuration to
use.